### PR TITLE
Fix: Update Dependencies and Patch Utils for Compatibility

### DIFF
--- a/code_tr/requirements.txt
+++ b/code_tr/requirements.txt
@@ -1,8 +1,11 @@
-diffusers==0.6.0
-transformers==4.24.0
+diffusers==0.11.1
+transformers==4.25.1
 einops==0.8.1
 opencv-python==4.10.0.84
-Pillow==9.5.0
+Pillow==10.4.0
 torch==1.13.1
 torchvision==0.14.1
-tqdm==4.66.5
+tqdm==4.67.1
+huggingface-hub==0.17.3
+xformers==0.0.16
+pyre-extensions==0.0.23


### PR DESCRIPTION
This PR addresses runtime errors encountered when setting up the environment and running the editing script based on the original `requirements.txt`.

**Changes:**

1.  **Updated `code_tr/requirements.txt`:**
    *   Upgraded `diffusers` from `0.6.0` to `0.11.1` and `transformers` from `4.24.0` to `4.25.1`. This resolves model loading incompatibilities (CLIPImageProcessor error) likely caused by updates to the SDv1.4 model configuration on the Hub.
    *   Downgraded `huggingface-hub` to `0.17.3` to fix a `cached_download` import error.
    *   Added `xformers==0.0.16` (and its dependency `pyre-extensions==0.0.23`) as it's required by the diffusers library for attention management.
    *   Updated Pillow/tqdm slightly based on dependencies.
2.  **Patched `code_tr/ptp_utils.py`:**
    *   Modified the custom attention forward function within `register_attention_control`.
    *   The fix corrects the handling of `encoder_hidden_states` when passed as a keyword argument in newer `diffusers` versions (like 0.11.1), resolving a shape mismatch error (`RuntimeError: mat1 and mat2 shapes cannot be multiplied`).

These changes allow the `code_tr/edit.sh` script to run successfully with the updated dependencies and the patched utility code.